### PR TITLE
bug fix missing commits from V1.2.0 

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -124,6 +124,7 @@ workflow {
         deduplication(umiTagging.out.dedup_in_ch)
         splitBamMi_ch = deduplication.out.bams
         splitBamLong_ch = deduplication.out.bams
+        report_dedup = deduplication.out.report_dedup
     } else {
         splitBamMi_ch = starAlign.out.starBam_ch
         splitBamLong_ch = starAlign.out.starBam_ch
@@ -143,11 +144,11 @@ workflow {
     //generate report
     assembleReport(
         fastQc.out.fastqc_results,
-        debarcode.out.report.ifEmpty([]),
+        report_debarcode,
         cutAdapt.out.report_trim,
         starAlign.out.report_star,
         picardAlignSummary.out.report_picard,
-        deduplication.out.report_dedup.ifEmpty([]),
+        report_dedup,
         countMicroRNA.out.report_miRNACounts,
         countLongRNA.out.report_longRNACounts,
         annoDirPath

--- a/src/htmlReport.R
+++ b/src/htmlReport.R
@@ -439,7 +439,7 @@ longRNAcounts <- rbind(data.frame(Result="Total Alignments", Count=sum(longRNAco
 longRNAcounts$`Count` <- cell_spec(
   prettyNum(longRNAcounts$`Count`, big.mark=",", scientific=FALSE),
   popover = spec_popover(
-    content = c("Total number of miRNA alignments",
+    content = c("Total number of longRNA alignments",
 		"longRNA alignments assigned to features",
                 "longRNA alignments not counted due to not mapping",
                 "longRNA alignments not counted due to mapping quality below MAPQ threshold",


### PR DESCRIPTION
Missed two fixes:

1. the old repo that we used to update complete had a error in the report when the user hovered over the longRNA total it was labeled as miRNA 
2. the empty channels for the report when skipUMI is true lead to breaking due the calling a the output of a module that did not run. 